### PR TITLE
Better handling of chain removal.

### DIFF
--- a/controllers/chain_controller.go
+++ b/controllers/chain_controller.go
@@ -24,7 +24,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	authcontroller "github.com/intel/authservice-configurator/api/v1"
 	authcontrollerv1 "github.com/intel/authservice-configurator/api/v1"
 )
 
@@ -47,13 +46,6 @@ type ChainReconciler struct {
 func (r *ChainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	logger := r.Log.WithValues("chain", req.NamespacedName)
-
-	// Get the updated chain.
-	var chain authcontroller.Chain
-	if err := r.Get(ctx, req.NamespacedName, &chain); err != nil {
-		logger.Error(err, "Chain not found, ignoring")
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
 
 	chains, err := getAllChains(r, logger, req.NamespacedName.Namespace)
 	if err != nil {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -205,10 +204,6 @@ func getAllChains(client client.Client, logger logr.Logger, namespace string) (*
 	if err := client.List(ctx, &chains, ctrlclient.InNamespace(namespace)); err != nil {
 		logger.Error(err, "Failed to get chain list, ignoring")
 		return nil, err
-	}
-
-	if len(chains.Items) == 0 {
-		return nil, fmt.Errorf("No chains found, ignoring")
 	}
 
 	return &chains, nil


### PR DESCRIPTION
Fix a chain removal bug. Previously, the detection of delete events was incomplete and chains weren't removed properly.

When the last chain is removed, remove also the "chains" field from the authservice configuration file. This causes authservice to not accept the configuration (and be in crash loop), but it is still better than having an outdated authservice configuration.